### PR TITLE
macOS compatible compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,10 @@ endif(COMPILE_PYTHON)
 
 
 install(TARGETS lemonade-bin lemonade-server lemonade-client RUNTIME)
-install(TARGETS ibus-engine-lemonade RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
-install(FILES ${CMAKE_BINARY_DIR}/lemonade.xml DESTINATION /usr/share/ibus/component)
+if(!APPLE)
+  install(TARGETS ibus-engine-lemonade RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+  install(FILES ${CMAKE_BINARY_DIR}/lemonade.xml DESTINATION /usr/share/ibus/component)
+endif(!APPLE)
  # install(FILES ${CMAKE_SOURCE_DIR}/logo/lemonade_logo.png DESTINATION share/icons)
  # install(FILES ${CMAKE_SOURCE_DIR}/logo/lemonade_logo.svg DESTINATION share/icons)
 endif(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+if(APPLE)
+    set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+endif()
+
 project(lemonade CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -30,7 +34,7 @@ SET(USE_WASM_COMPATIBLE_SOURCE OFF CACHE BOOL "Don't build wasm compatible sourc
 find_package(Threads REQUIRED) # Cross-platform compatible way to get threads?
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Network DBus REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui PrintSupport Widgets LinguistTools Network DBus Svg REQUIRED)
-
+find_package(OpenSSL REQUIRED)
 
 include(GetVersionFromFile)
 message(STATUS "Project name: ${PROJECT_NAME}")
@@ -49,6 +53,7 @@ set(PROJECT_LICENSE "GPL")
 set(LEMONADE_INCLUDE_DIRECTORIES 
     ${CMAKE_SOURCE_DIR}/3rd_party/CLI
     ${CMAKE_SOURCE_DIR}/3rd_party/rapidjson/include
+    ${OPENSSL_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}
 )
 
@@ -58,6 +63,7 @@ set(LINK_LIBRARIES
     Qt${QT_VERSION_MAJOR}::Network
     Qt${QT_VERSION_MAJOR}::DBus
     ${LibArchive_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
     ${CMAKE_DL_LIBS} # On unix necessary sometimes
 )
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ You might also want to checkout
 [translateLocally](https://github.com/XapaJIaMnu/translateLocally), which is
 cross-platform and GUI.
 
+## Installation
+
+Dependencies:
+
+- Qt
+- pybind11
+- libarchive
+
+### Python bindings on macOS
+Assuming you have Qt installed through the official Qt distribution, it would
+be something this, where you might need to change the path to your version of
+Qt.
+
+```sh
+CMAKE_ARGS="-DCMAKE_PREFIX_PATH=$HOME/Qt/6.2.2/macos;$(brew --prefix pybind11)" pip3 install path/to/lemonade
+```
 
 ## Acknowledgements
 

--- a/lemonade/CMakeLists.txt
+++ b/lemonade/CMakeLists.txt
@@ -1,4 +1,7 @@
 
 add_subdirectory(lib)
 add_subdirectory(bin)
-add_subdirectory(ibus)
+
+if(!APPLE)
+  add_subdirectory(ibus)
+endif(!APPLE)

--- a/lemonade/lib/json_interop.h
+++ b/lemonade/lib/json_interop.h
@@ -67,8 +67,8 @@ toJSON<marian::bergamot::Response>(const marian::bergamot::Response &response) {
                   rapidjson::Value vWord;
                   auto word = annotation.word(s, w);
                   vWord.SetArray();
-                  vWord.PushBack(word.begin, allocator);
-                  vWord.PushBack(word.end, allocator);
+                  vWord.PushBack(static_cast<uint64_t>(word.begin), allocator);
+                  vWord.PushBack(static_cast<uint64_t>(word.end), allocator);
                   vSentence.PushBack(vWord, allocator);
                 }
                 vAnnotation.PushBack(vSentence, allocator);

--- a/lemonade/lib/utils.cpp
+++ b/lemonade/lib/utils.cpp
@@ -1,17 +1,16 @@
 #include "utils.h"
-#include <bits/types/time_t.h> // for time_t
 #include <ctime>               // for localtime, time
 
 namespace lemonade {
 
 std::string currentTime() {
   // https://stackoverflow.com/a/16358264/4565794
-  time_t rawtime;
+  std::time_t rawtime;
   struct tm *timeinfo;
   char buffer[80];
 
-  time(&rawtime);
-  timeinfo = localtime(&rawtime);
+  std::time(&rawtime);
+  timeinfo = std::localtime(&rawtime);
 
   strftime(buffer, sizeof(buffer), "%d-%m-%Y %H:%M:%S", timeinfo);
   return std::string(buffer);

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class CMakeBuild(build_ext):
             f"-DSSPLIT_USE_INTERNAL_PCRE2=ON",
 
         ]
-        build_args = []
+        build_args = ['-t', '_bergamot']
         # Adding CMake arguments set as environment variable
         # (needed e.g. to build for ARM OSx on conda-forge)
         if "CMAKE_ARGS" in os.environ:


### PR DESCRIPTION
These are the changes I needed to make to get it to compile without errors on macOS with clang and homebrew.

One thing that needs a bit of explaining: In marian, there is this bit:

```diff
diff --git a/src/3rd_party/zstr/strict_fstream.hpp b/src/3rd_party/zstr/strict_fstream.hpp
index 7b1173931df977e69021f3995fa064a492f89d38..948e91eaf99b6b29ce41cf793fba6717f3b5f5b5 100644
--- a/src/3rd_party/zstr/strict_fstream.hpp
+++ b/src/3rd_party/zstr/strict_fstream.hpp
@@ -27,7 +27,7 @@ static std::string strerror()
     {
         buff = "Unknown error";
     }
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__) && ! _GNU_SOURCE
+#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__)
 // XSI-compliant strerror_r()
     if (strerror_r(errno, &buff[0], buff.size()) != 0)
     {
```

Normally this code compiles just fine on macOS as `_GNU_SOURCE` is (correctly) undefined. However, it seems that `pyconfig.h`, one of the python headers necessary for bindings, includes this bit:

```c
/* Enable GNU extensions on systems that have them.  */
#ifndef _GNU_SOURCE
# define _GNU_SOURCE 1
#endif
```

I have not yet found a way to get around this, other than changing `strict_fstream.hpp` manually.